### PR TITLE
Added support for the date-time format

### DIFF
--- a/src/bootstrap-datepicker.js
+++ b/src/bootstrap-datepicker.js
@@ -3,7 +3,7 @@ angular.module('schemaForm').config(
   function(schemaFormProvider,  schemaFormDecoratorsProvider, sfPathProvider) {
 
     var datepicker = function(name, schema, options) {
-      if (schema.type === 'string' && schema.format === 'date') {
+      if (schema.type === 'string' && (schema.format === 'date' || schema.format === 'date-time')) {
         var f = schemaFormProvider.stdFormObj(name, schema, options);
         f.key  = options.path;
         f.type = 'datepicker';


### PR DESCRIPTION
The "date" format is not in [the latest (v4) json schema draft](http://json-schema.org/latest/json-schema-core.html). It must have been removed, but I've kept "date" in for backwards compatibility.
