### PR TITLE
added plumber to prevent watch from quitting on error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
 var streamqueue = require('streamqueue');
 var jscs = require('gulp-jscs');
+var plumber = require('gulp-plumber');
 
 gulp.task('minify', function() {
   var stream = streamqueue({objectMode: true});
@@ -51,6 +52,7 @@ gulp.task('non-minified-dist', function() {
 
 gulp.task('jscs', function() {
   gulp.src('./src/**/*.js')
+      .pipe(plumber())
       .pipe(jscs());
 });
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-concat": "^2.2.0",
     "gulp-jscs": "^1.1.0",
     "gulp-minify-html": "^0.1.1",
+    "gulp-plumber": "^0.6.5",
     "gulp-uglify": "^0.2.1",
     "karma": "^0.12.0",
     "karma-chai-sinon": "^0.1.3",


### PR DESCRIPTION
In the current setup the slightest syntax error freaks the `watch` task out the moment `jscs()` spits out an error. Plumber keeps `watch` running and patiently waits for the error to be fixed, rerunning `watch`.
