### PR TITLE
Made it possible to set the date format used by the date picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ mapping.
 
 Form Type Options
 -------
-The `datepicker` form type takes two options: `minDate` and `maxDate`. `minDate` and `maxDate` both
-accept one of the following as values:
+The `datepicker` form type takes two date range options: `minDate` and `maxDate`. `minDate` and `maxDate` both accept one of the following as values:
 
 1. A string in the format `yyyy-mm-dd`,
 2. A unix timestamp (as a Number), or
 3. An instance of `Date`
+
+It is also possible to set the date format using the `format` option, which is used to format the date stored by angularjs.
 
 Here's an example:
 
@@ -65,6 +66,7 @@ Here's an example:
 {
   key: "birthDate",
   minDate: "1900-01-01",
-  maxDate: new Date()
+  maxDate: new Date(),
+  format: "YYYY-MM-DD"
 }
 ```

--- a/src/angular-pickadate.js
+++ b/src/angular-pickadate.js
@@ -17,7 +17,8 @@ angular.module('schemaForm').directive('pickADate', function () {
     scope: {
       ngModel: '=',
       minDate: '=',
-      maxDate: '='
+      maxDate: '=',
+      format: '='
     },
     link: function (scope, element, attrs, ngModel) {
       //Bail out gracefully if pickadate is not loaded.
@@ -52,15 +53,15 @@ angular.module('schemaForm').directive('pickADate', function () {
 
         //We set 'view' and 'highlight' instead of 'select'
         //since the latter also changes the input, which we do not want.
-        picker.set('view', value, {format: attrs.format || defaultFormat});
-        picker.set('highlight', value, {format: attrs.format || defaultFormat});
+        picker.set('view', value, {format: scope.format || defaultFormat});
+        picker.set('highlight', value, {format: scope.format || defaultFormat});
 
         //piggy back on highlight to and let pickadate do the transformation.
         return picker.get('highlight', viewFormat);
       });
 
       ngModel.$parsers.push(function() {
-        return picker.get('select', attrs.format || defaultFormat);
+        return picker.get('select', scope.format || defaultFormat);
       });
 
       //bind once.

--- a/src/datepicker.html
+++ b/src/datepicker.html
@@ -9,7 +9,8 @@
          ng-model="$$value$$"
          pick-a-date
          min-date="form.minDate"
-         max-date="form.maxDate" />
+         max-date="form.maxDate"
+         format="form.format" />
 
   <span class="help-block">{{ (hasError() && errorMessage(schemaError())) || form.description}}</span>
 </div>


### PR DESCRIPTION
I'd like to be able to store dates in a format other than the default (ie. YYYY-MM-DD). The date picker uses angular formatters for converting the date to a default format, but it currently doesn't allow that default to be overridden.

This PR should make it possible to specify an format in the form object, which is then passed to pickadate.
