### PR TITLE
Support pickadate options by form.pickadate. resolve #7, #11

### DIFF
--- a/src/angular-pickadate.js
+++ b/src/angular-pickadate.js
@@ -16,6 +16,7 @@ angular.module('schemaForm').directive('pickADate', function () {
     require: 'ngModel',
     scope: {
       ngModel: '=',
+      pickADate: '=',
       minDate: '=',
       maxDate: '=',
       format: '='
@@ -29,12 +30,16 @@ angular.module('schemaForm').directive('pickADate', function () {
       //By setting formatSubmit to null we inhibit the
       //hidden field that pickadate likes to create.
       //We use ngModel formatters instead to format the value.
-      element.pickadate({
+      var opts = {
         onClose: function () {
           element.blur();
         },
         formatSubmit: null
-      });
+      };
+      if (scope.pickADate) {
+        angular.extend(opts, scope.pickADate);
+      }
+      element.pickadate(opts);
 
       //Defaultformat is for json schema date-time is ISO8601
       //i.e.  "yyyy-mm-dd"

--- a/src/datepicker.html
+++ b/src/datepicker.html
@@ -7,7 +7,7 @@
          class="form-control {{form.fieldHtmlClass}}"
          schema-validate="form"
          ng-model="$$value$$"
-         pick-a-date
+         pick-a-date="form.pickadate"
          min-date="form.minDate"
          max-date="form.maxDate"
          format="form.format" />


### PR DESCRIPTION
It is exactly the reason why the angular-schema-form add-on amount are so small and not usable, all because we lost the control to the input control by the form definition.

but we have to live with it. so here's the overcome version support pickadate options by the form.pickadate, e.g.
```
{
  "key": "birthday",
  "type": "datepicker",
  "pickadate": {
    "selectYears": true, 
    "selectMonths": true
  }
}
```